### PR TITLE
fix maxScrollTop after page load(if many images in the content)

### DIFF
--- a/source/js/theme.js
+++ b/source/js/theme.js
@@ -18,7 +18,7 @@ $(function() {
   });
 
   // Post follow sidebar
-  $(function() {
+  (function() {
     var $sidebar    = $("#sidebar"),
         $tags       = $('.tags'),
         $headerlink = $(".headerlink"),
@@ -28,7 +28,9 @@ $(function() {
       var minScrollTop = $sidebar.offset().top,
           maxScrollTop = $tags.offset().top - $sidebar.height();
 
-
+      $(window).load(function() {
+        maxScrollTop = $tags.offset().top - $sidebar.height();
+      });
       $(window).scroll(function () {
         var scrollTop     = $(window).scrollTop();
 
@@ -62,5 +64,5 @@ $(function() {
         }
       });
     }
-  });
+  })();
 });


### PR DESCRIPTION
内容有图片时，sidebar 滚动区域计算有问题