### PR TITLE
修复 theme_color 未配置时错误

### DIFF
--- a/source/css/_global.scss
+++ b/source/css/_global.scss
@@ -6,7 +6,7 @@
 
 // =============== Global ===============//
 
-$theme-color-config: hexo-theme-config('theme_color');
+$theme-color-config: hexo-theme-config('theme_color') !default;
 
 $theme-color-map: (
   'Default': #c05b4d #f8f5ec,
@@ -16,10 +16,8 @@ $theme-color-map: (
   'Dark Violet': #9932CC #f5f4fa
 ) !default;
 
-$theme-color: map-get($theme-color-map, 'Default');
-@if $theme-color-config != 'Default' {
-  $theme-color: map-get($theme-color-map, $theme-color-config);
-}
+$theme-color-config: if(map-has-key($theme-color-map, $theme-color-config), $theme-color-config, 'Default');
+$theme-color: map-get($theme-color-map, $theme-color-config);
 
 // Default theme color of the site.
 // @type Color

--- a/source/css/partial/_post.scss
+++ b/source/css/partial/_post.scss
@@ -92,6 +92,7 @@ $content-table-bg: lighten(#f8f5ec, 30%) !default;
 
       a {
         color: $global-theme-color;
+        word-break: break-all;
 
         &:hover {
           border-bottom: $content-link-border;

--- a/source/css/partial/_tags.scss
+++ b/source/css/partial/_tags.scss
@@ -34,6 +34,7 @@ $tag-link-margin: 5px !default;
     a {
       margin-right: 5px;
       color: $global-theme-color;
+      word-break: break-all;
 
       &::before {
         content: '#';
@@ -72,7 +73,7 @@ $tag-link-margin: 5px !default;
       &:focus,
       &:hover {
         color: $global-theme-color;
-        transform: scale(1.05); 
+        transform: scale(1.05);
       }
     }
   }


### PR DESCRIPTION
1. 修复 `theme_color` 未配置时错误
2. 允许post和tags 里的链接换行，以修复手机端被撑开问题。