### PR TITLE
fix smoothScroll() in source/js/theme.js

### DIFF
--- a/source/js/theme.js
+++ b/source/js/theme.js
@@ -21,14 +21,16 @@ $(function() {
       if (duration < 0) {
         return;
       }
+      var perTickDur = 10;
       var difference = to - $(window).scrollTop();
-      var perTick = difference / duration * 10;
-      this.scrollToTimerCache = setTimeout(function() {
-        if (!isNaN(parseInt(perTick, 10))) {
-          window.scrollTo(0, $(window).scrollTop() + perTick);
-          smoothScroll(el, to, duration - 10);
+      var perTickDiff = difference / duration * perTickDur;
+      // console.log(difference);
+      setTimeout(function() {
+        if (!isNaN(parseInt(perTickDiff, 10))) {
+          window.scrollTo(0, $(window).scrollTop() + perTickDiff);
+          smoothScroll(el, to, duration - perTickDur);
         }
-      }.bind(this), 10);
+      }, perTickDur);
     }
 
     $back2top.click(function (e) {


### PR DESCRIPTION
hi~ 我发现每次我点击右下角那个"#back2top"的时候，console 里总是冒出来一堆 `theme.js:26 Uncaught TypeError: Cannot set property 'scrollToTimerCache' of undefined(…)` 虽然不影响实际使用，奈何强迫症>_<

试着 console.log() 了一下，发现 `this` 在这种情况下是 undefined 的…

我不熟悉 javascript， 所以不太清楚为什么会这样，我的解决方法是直接把 `this.scrollToTimerCache` 删掉了，看上去还能工作的样子…

---

p.s. my environment: Chrome/54.0.2840.71 ( Windows 10 ).

Not sure whether I fixed this in the right way, so feel free if you want to close this pull request and fix it by yourself :)