### PR TITLE
Fixed typos, added multi-language copyright statement

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,8 @@ theme:
 copyright:
   enable: true
   # https://creativecommons.org/
-  license: '本文采用<a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/">知识共享署名-非商业性使用 4.0 国际许可协议</a>进行许可'
+  # moved to separate language files (zh and en)
+  # license: '本文采用<a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/">知识共享署名-非商业性使用 4.0 国际许可协议</a>进行许可'
 
 reward:
   enable: false

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -22,6 +22,7 @@ copyright:
   author: 'Author'
   link: 'Link'
   origin: 'Origin'
+  license: 'This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution-Noncommercial 4.0 International License</a>'
 
 counter:
   archives:

--- a/languages/zh.yml
+++ b/languages/zh.yml
@@ -22,6 +22,7 @@ copyright:
   author: '作者'
   link: '链接'
   origin: '来源'
+  license: '本文采用<a rel="license" href="http://creativecommons/licenses/by-nc/4.0/">知识共享署名-非商业性使用 4.0 国际许可协议</a>进行许可'
 
 counter:
   archives:

--- a/layout/_layout.swig
+++ b/layout/_layout.swig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ connfig.language }}">
+<html lang="{{ config.language }}">
   <head>
     {% include '_partial/head.swig' %}
     <title>{% block title %}{% endblock %}</title>

--- a/layout/_partial/_post/copyright.swig
+++ b/layout/_partial/_post/copyright.swig
@@ -15,8 +15,7 @@
     </p>
 
     <p class="copyright-item lincese">
-      {% set lincese = page.lincese || theme.copyright.license %}
-      {{ lincese }}
+      {{ __('copyright.license') }}
     </p>
   </div>
 {% endif %}

--- a/layout/categories.swig
+++ b/layout/categories.swig
@@ -8,7 +8,7 @@
       {{ _p('counter.categories', site.categories.length) }}
     </div>
     <div class="categories-tags">
-      {{ list_categories({style: null, separator: ' ', depth: '-1'}) }}
+      {{ list_categories({style: null, separator: ' ', depth: '0'}) }}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
这个commit主要是让不同的language下可以显示相应语言的copyright statement。
connfig那里应该是一个typo。
category的depth那里，在官方文档中没有看到depth=-1代表什么意思，要正常显示所有分类（包括次级分类），应该是0。

hexo新手，代码可能改得不太规范，请您酌情采纳。