### PR TITLE
Unifying the name of code-highlight-color

### DIFF
--- a/source/css/_variables.scss
+++ b/source/css/_variables.scss
@@ -196,7 +196,7 @@ $code-highlight-color: (
   comment: #93a1a1,
   keyword: #859900,
   number: #2aa198,
-  name: #268bd2,
+  title: #268bd2,
   attribute: #b58900,
   symbol: #cb4b16,
   built_in: #dc322f


### PR DESCRIPTION
_variables.scss 中 code-highlight-color 定义为`name`，但_code.scss line 137 使用`title`获取 #171 