### PR TITLE
add valine comment system

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -89,6 +89,15 @@ changyan:
   appid:
   appkey:
 
+# Valine comment https://valine.js.org
+valine:
+  appid:  # your leancloud appid
+  appkey:  # your leancloud appkey
+  notify: false # true/false:mail notify !!!Test,Caution. https://github.com/xCss/Valine/wiki/Valine-%E8%AF%84%E8%AE%BA%E7%B3%BB%E7%BB%9F%E4%B8%AD%E7%9A%84%E9%82%AE%E4%BB%B6%E6%8F%90%E9%86%92%E8%AE%BE%E7%BD%AE
+  verify: false # true/false:verify code
+  avatar: mm # avatar style https://github.com/xCss/Valine/wiki/avatar-setting-for-valine
+  placeholder: Just go go # comment box placeholder
+
 # ===========================================
 # Version
 # ===========================================

--- a/layout/_partial/comments.swig
+++ b/layout/_partial/comments.swig
@@ -7,6 +7,8 @@
           <a href="//disqus.com/?ref_noscript">comments powered by Disqus.</a>
         </noscript>
       </div>
+    {% elseif theme.valine.appid and theme.valine.appkey %}
+      <div id="vcomments"></div>
     {% endif %}
   </div>
 {% endif %}

--- a/layout/_script/_comments/valine.swig
+++ b/layout/_script/_comments/valine.swig
@@ -1,0 +1,16 @@
+{% if theme.valine.appid and theme.valine.appkey %}
+<!-- valine Comments -->
+<script src="//cdn1.lncld.net/static/js/3.0.4/av-min.js"></script>
+<script src="//cdn.jsdelivr.net/gh/xcss/valine@v1.1.7/dist/Valine.min.js"></script>
+<script type="text/javascript">
+    new Valine({
+        el: '#vcomments',
+        notify: {{ theme.valine.notify }},
+        verify: {{ theme.valine.verify }},
+        app_id: "{{ theme.valine.appid }}",
+        app_key: "{{ theme.valine.appkey }}",
+        placeholder: "{{ theme.valine.placeholder }}",
+        avatar: '{{ theme.valine.avatar }}'
+    });
+</script>
+{% endif %}

--- a/layout/_script/comments.swig
+++ b/layout/_script/comments.swig
@@ -1,3 +1,9 @@
 {% if !is_home() and !is_archive() %}
-  {% include "_comments/disqus.swig" %}
+  {% if theme.disqus_shortname %}
+    {% include "_comments/disqus.swig" %}
+  {% elseif theme.changyan and theme.changyan.appid and theme.changyan.appkey %}
+    {% include "_comments/changyan.swig" %}
+  {% elseif theme.valine.appid and theme.valine.appkey %}
+    {% include "_comments/valine.swig" %}
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
- Add [valine](https://valine.js.org) comment system.
- Add comment system judgment.
### _config.yml
```yaml
# Valine comment https://valine.js.org
valine:
  appid:  # your leancloud appid
  appkey:  # your leancloud appkey
  notify: false # true/false:mail notify !!!Test,Caution. https://github.com/xCss/Valine/wiki/Valine-%E8%AF%84%E8%AE%BA%E7%B3%BB%E7%BB%9F%E4%B8%AD%E7%9A%84%E9%82%AE%E4%BB%B6%E6%8F%90%E9%86%92%E8%AE%BE%E7%BD%AE
  verify: false # true/false:verify code
  avatar: mm # avatar style https://github.com/xCss/Valine/wiki/avatar-setting-for-valine
  placeholder: Just go go # comment box placeholder
```
### layout/_partial/comments.swig
```swig
    {% elseif theme.valine.appid and theme.valine.appkey %}
      <div id="vcomments"></div>
    {% endif %}
```
### layout/_script/_comments/valine.swig
```swig
{% if theme.valine.appid and theme.valine.appkey %}
<!-- valine Comments -->
<script src="//cdn1.lncld.net/static/js/3.0.4/av-min.js"></script>
<script src="//cdn.jsdelivr.net/gh/xcss/valine@v1.1.7/dist/Valine.min.js"></script>
<script type="text/javascript">
    new Valine({
        el: '#vcomments',
        notify: {{ theme.valine.notify }},
        verify: {{ theme.valine.verify }},
        app_id: "{{ theme.valine.appid }}",
        app_key: "{{ theme.valine.appkey }}",
        placeholder: "{{ theme.valine.placeholder }}",
        avatar: '{{ theme.valine.avatar }}'
    });
</script>
{% endif %}
```
### layout/_script/comments.swig
> Add comment system judgment.
```swig
  {% if theme.disqus_shortname %}
    {% include "_comments/disqus.swig" %}
  {% elseif theme.changyan and theme.changyan.appid and theme.changyan.appkey %}
    {% include "_comments/changyan.swig" %}
  {% elseif theme.valine.appid and theme.valine.appkey %}
    {% include "_comments/valine.swig" %}
  {% endif %}
```
[![Preview](https://ws1.sinaimg.cn/large/006qRazegy1fkuq5cp9f7j31gu0q90tw.jpg)](https://ws1.sinaimg.cn/large/006qRazegy1fkuq5cp9f7j31gu0q90tw.jpg)