### PR TITLE
feat: 阅读次数显示优化

### DIFF
--- a/source/css/_partial/_post/_header.scss
+++ b/source/css/_partial/_post/_header.scss
@@ -40,6 +40,7 @@
       display: inline-block;
       font-size: 14px;
       color: $post-meta-font-color;
+      visibility: hidden;
 
       &::before {
         content: '·';

--- a/source/js/src/even.js
+++ b/source/js/src/even.js
@@ -131,7 +131,7 @@
 
     function updateVisits(dom, time) {
       var text = dom.text() + ' ' + time;
-      dom.text(text);
+      dom.text(text).css('visibility', 'visible');
     }
 
     function addCounter(Counter) {


### PR DESCRIPTION
关于阅读次数的显示，目前是先显示`阅读次数`四个字，待从 leancloud 拉回数据后才会显示数字，那么在数据还没拉回的时候用户体验不太好。更改为数据拉回后再显示`阅读次数`四个字，具体效果如下：
![image](https://user-images.githubusercontent.com/28722527/36793631-dce94330-1cd8-11e8-9fb1-87a0e56be8ec.png)

![image](https://user-images.githubusercontent.com/28722527/36793641-e0a49ea2-1cd8-11e8-9154-8ae1cd9a2a53.png)
