### PR TITLE
use pjax to improve the user experience

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,7 @@ theme:
   color: Default
   toc: false
   fancybox: false
+  pjax: true
 
 copyright:
   enable: true

--- a/layout/_partial/head.swig
+++ b/layout/_partial/head.swig
@@ -26,6 +26,11 @@
   <link rel="stylesheet" type="text/css" href="{{ url_for('lib/fancybox/jquery.fancybox.css') }}" />
 {% endif %}
 
+{# Nprogress styling #}
+{% if theme.theme.pjax %}
+  <link href="https://cdn.bootcss.com/nprogress/0.2.0/nprogress.min.css" rel="stylesheet">
+{% endif %}
+
 {# Analytics and push #}
 {% if not env.debug %}
   {% include "../_script/analytics.swig" %}

--- a/layout/_script/libs.swig
+++ b/layout/_script/libs.swig
@@ -15,3 +15,8 @@
     <script type="text/javascript" src="{{ url_for('lib') }}/{{ lib }}"></script>
   {% endif %}
 {% endfor %}
+
+{% if theme.theme.pjax %}
+  <script src="https://cdn.bootcss.com/jquery.pjax/2.0.1/jquery.pjax.min.js"></script>
+  <script src="https://cdn.bootcss.com/nprogress/0.2.0/nprogress.min.js"></script>
+{% endif %}

--- a/source/js/src/even.js
+++ b/source/js/src/even.js
@@ -198,4 +198,15 @@
   }
 
   window.Even = Even;
+
+  $(function () {
+	$(document).pjax('a', 'body', {fragment: 'body'});
+	$(document).on('pjax:send', function() {
+		NProgress.start();
+	})
+	$(document).on('pjax:complete', function() {
+		NProgress.done();
+	})
+  })
+
 })(window);


### PR DESCRIPTION
1. 使用 pjax 和 Nprogress 提升用户体验，减少静态资源（js 和 css）的重复请求。
2. 可在 `_config.yml` 配置文件中决定是否开启 pjax 功能，默认开启：
```yml
theme:
  pjax: true
```
3. pjax 和 nprogress 使用 bootcdn 提供的 cdn 服务
4. 查看效果：http://wencaizhang.com/blog/