### PR TITLE
LeanCloud must need write access for time modify.

### DIFF
--- a/source/js/src/even.js
+++ b/source/js/src/even.js
@@ -177,6 +177,11 @@
           newcounter.set('url', url);
           newcounter.set('time', 1);
 
+          var acl = new AV.ACL();
+          acl.setWriteAccess('*', true)
+          acl.setReadAccess('*', true)
+          newcounter.setACL(acl)
+
           newcounter.save().then(function () {
             updateVisits($visits, newcounter.get('time'));
           });


### PR DESCRIPTION
When I use LeanCloud record readings. this function will use
default ACL: `{"*":{"read":true,"write":false}}`, when you
run `counter.save`, it will give an error.

After I modify, the ACL will be `{"*":{"write":true,"read":true}}`,
the save operation works fine.

> I don't know if someone else has encountered this problem, or
> if there are other solutions. I check the LeanCloud API, then
> make a choice to change the ACL.


我不清楚是不是只有我遇到了这个问题, 还是说有其他解决方案.

Signed-off-by: corvofeng <corvofeng@gmail.com>