### PR TITLE
Fix fancybox init failure while pjax is on

### DIFF
--- a/source/js/src/even.js
+++ b/source/js/src/even.js
@@ -225,6 +225,7 @@
     if (location.hostname === 'localhost' || this.hasPjax) return;
     this.hasPjax = true;
     this._fancybox = $.fancybox;
+    this._fancyboxProto = $.prototype.fancybox;
 
     var that = this;
     $(document).pjax('a', 'body', { fragment: 'body' });
@@ -236,6 +237,7 @@
       NProgress.done();
       $('body').removeClass('hide-top');
       $.fancybox = that._fancybox;
+      $.prototype.fancybox = that._fancyboxProto;
       that.setup();
     });
   };

--- a/source/js/src/even.js
+++ b/source/js/src/even.js
@@ -224,6 +224,7 @@
   Even.prototype.pjax = function () {
     if (location.hostname === 'localhost' || this.hasPjax) return;
     this.hasPjax = true;
+    this._fancybox = $.fancybox;
 
     var that = this;
     $(document).pjax('a', 'body', { fragment: 'body' });
@@ -234,6 +235,7 @@
     $(document).on('pjax:complete', function () {
       NProgress.done();
       $('body').removeClass('hide-top');
+      $.fancybox = this._fancybox;
       that.setup();
     });
   };

--- a/source/js/src/even.js
+++ b/source/js/src/even.js
@@ -235,7 +235,7 @@
     $(document).on('pjax:complete', function () {
       NProgress.done();
       $('body').removeClass('hide-top');
-      $.fancybox = this._fancybox;
+      $.fancybox = that._fancybox;
       that.setup();
     });
   };


### PR DESCRIPTION
closes #234 

This bug was caused by https://github.com/ahonn/hexo-theme-even/blob/ae2df791cbee904dc811d08d7375487829cdfd95/source/js/src/even.js#L131

After navigating among pages through pjax, the `$.fancybox` becomes `undefined`. So we store it temporarily.