### PR TITLE
fix: wrong `active` toc list item because LaTeX renderer may cause headers' position to change

### DIFF
--- a/source/js/src/even.js
+++ b/source/js/src/even.js
@@ -109,11 +109,10 @@
     var $toclink = $('.toc-link'),
       $headerlink = $('.headerlink');
 
-    var headerlinkTop = $.map($headerlink, function (link) {
-      return $(link).offset().top;
-    });
-
     $(window).scroll(function () {
+      var headerlinkTop = $.map($headerlink, function (link) {
+        return $(link).offset().top;
+      });
       var scrollTop = $(window).scrollTop();
 
       for (var i = 0; i < $toclink.length; i++) {


### PR DESCRIPTION
Currently, the sidebar toc should responses to user's `scroll` event (registered in `even.js: Even.prototype.tocFollow`), but it will behave unexpectedly if LaTeX renderer (MathJax) renders some LaTeX codes to svg/HTML+CSS, it may take larger/smaller space, which breaks the `tocFollow` function.

This PR should fix the problem, by re-evaluating positions of headers every time the `scroll` handler was called.

This PR is an amendment for PR #236 