### PR TITLE
add word wrap to copyright item

### DIFF
--- a/source/css/_partial/_post/_code.scss
+++ b/source/css/_partial/_post/_code.scss
@@ -9,6 +9,9 @@ code {
   padding: 3px 5px;
   border-radius: 4px;
   color: $code-color;
+  word-break: normal;
+  white-space: pre-warp;
+  word-wrap: break-word;
 }
 
 .highlight {

--- a/source/css/_partial/_post/_copyright.scss
+++ b/source/css/_partial/_post/_copyright.scss
@@ -5,6 +5,9 @@
 
   .copyright-item {
     margin: 5px 0;
+    word-break: normal;
+    white-space: pre-warp;
+    word-wrap: break-word;
 
     a {
       color: $theme-color;


### PR DESCRIPTION
Chrome Version: 83.0.4163
OS: Android 8.1
The link of copyright item dose not wrap.

![Screenshot_20200802_181325.png](https://i.loli.net/2020/08/02/ysa1NFq67Kor9AT.png)

add word wrap to copyright item.