### PR TITLE
auto scroll toc && add interval while showing visitTime

### DIFF
--- a/source/js/src/even.js
+++ b/source/js/src/even.js
@@ -87,13 +87,17 @@
         } else {
           $toc.css(tocState.process);
           
-          if($('.toc-link.active').offset() != undefined && $('.toc-link.active').offset().top - document.documentElement.scrollTop > window.innerHeight*1/2){
-            $('.post-toc').offset({top:Math.min($footer.offset().top - $toc.height()- SPACING,window.innerHeight*1/2 + document.documentElement.scrollTop - ($('.toc-link.active').offset().top - $('.post-toc').offset().top))});
+          var maxTocTop = $footer.offset().top - $toc.height() - SPACING;
+          var tocCenterThreshold = document.documentElement.scrollTop + window.innerHeight / 2;
+          if ($(".toc-link.active").offset() != undefined && $(".toc-link.active").offset().top > tocCenterThreshold) {
+            var distanceBetween = $(".post-toc").offset().top - $(".toc-link.active").offset().top;
+            $(".post-toc").offset({
+                top: Math.min(maxTocTop, tocCenterThreshold + distanceBetween),
+            });
           }
-          if($footer.offset().top <$('.post-toc').offset().top + $toc.height() + SPACING){
-            $('.post-toc').offset({top:$footer.offset().top- $toc.height()-SPACING});
+          if (maxTocTop < $(".post-toc").offset().top) {
+            $(".post-toc").offset({ top: maxTocTop });
           }
-          //   $('.toc').offset({top:window.innerHeight/2 + document.documentElement.scrollTop - ($('.toc-link.active').offset().top - $('.toc').offset().top)});
         }
       })
     }

--- a/source/js/src/even.js
+++ b/source/js/src/even.js
@@ -70,32 +70,30 @@
 
     if ($toc.length) {
       var minScrollTop = $toc.offset().top - SPACING;
-      var maxScrollTop = $footer.offset().top - $toc.height() - SPACING;
-
-      var tocState = {
-        start: {
-          'position': 'absolute',
-          'top': minScrollTop
-        },
-        process: {
-          'position': 'fixed',
-          'top': SPACING
-        },
-        end: {
-          'position': 'absolute',
-          'top': maxScrollTop
-        }
-      }
-
       $(window).scroll(function () {
+        var tocState = {
+          start: {
+            'position': 'absolute',
+            'top': minScrollTop
+          },
+          process: {
+            'position': 'fixed',
+            'top': SPACING
+          }
+        }
         var scrollTop = $(window).scrollTop();
-
         if (scrollTop < minScrollTop) {
           $toc.css(tocState.start);
-        } else if (scrollTop > maxScrollTop) {
-          $toc.css(tocState.end);
         } else {
           $toc.css(tocState.process);
+          
+          if($('.toc-link.active').offset() != undefined && $('.toc-link.active').offset().top - document.documentElement.scrollTop > window.innerHeight*1/2){
+            $('.post-toc').offset({top:Math.min($footer.offset().top - $toc.height()- SPACING,window.innerHeight*1/2 + document.documentElement.scrollTop - ($('.toc-link.active').offset().top - $('.post-toc').offset().top))});
+          }
+          if($footer.offset().top <$('.post-toc').offset().top + $toc.height() + SPACING){
+            $('.post-toc').offset({top:$footer.offset().top- $toc.height()-SPACING});
+          }
+          //   $('.toc').offset({top:window.innerHeight/2 + document.documentElement.scrollTop - ($('.toc-link.active').offset().top - $('.toc').offset().top)});
         }
       })
     }

--- a/source/js/src/even.js
+++ b/source/js/src/even.js
@@ -197,23 +197,27 @@
     }
 
     function showTime(Counter) {
+      let index = 0;
       $visits.each(function () {
         var $this = $(this);
-        var query = new AV.Query(Counter);
-        var url = $this.data('url').trim();
-
-        query.equalTo('url', url);
-        query.find().then(function (results) {
-          if (results.length === 0) {
-            updateVisits($this, 0);
-          } else {
-            var counter = results[0];
-            updateVisits($this, counter.get('time'));
-          }
-        }, function (error) {
-          // eslint-disable-next-line
-          console.log('Error:' + error.code + ' ' + error.message);
-        });
+        setTimeout(
+          function() {
+            var query = new AV.Query(Counter);
+            var url = $this.data('url').trim();
+    
+            query.equalTo('url', url);
+            query.find().then(function (results) {
+              if (results.length === 0) {
+                updateVisits($this, 0);
+              } else {
+                var counter = results[0];
+                updateVisits($this, counter.get('time'));
+              }
+            }, function (error) {
+              // eslint-disable-next-line
+              console.log('Error:' + error.code + ' ' + error.message);
+            });
+          }, 100*(index++));     
       })
     }
   };


### PR DESCRIPTION
1. 计算页面长度的时候是用的加载之后的值，其中可能有没渲染好的图片或者其它资源后续又撑高了页面，所以应该每次都改
2. 目录跟随页面滚动而自动滚动，感觉自动折叠的逻辑对多个同级的目录不友好所以选择了这种方式，个人觉得比现在的效果好，可以先用着，pc端的demo页面：[Sync Sofa](https://onns.xyz/blog/2020/08/12/sync-sofa-doc/)

---

1. leancloud对免费账号有并发3次的限制，所以一次无法获取到所有的访问次数，加了个小小的延时，体验优化。