### PR TITLE
support cusdis

### DIFF
--- a/layout/_partial/comments.swig
+++ b/layout/_partial/comments.swig
@@ -15,6 +15,14 @@
       <div id="gitalk-container"></div>
     {%- elif theme.utterances.enable -%}
       <div id="utterances-container"></div>
+    {%- elif theme.cusdis.app_id -%}
+      <div id="cusdis_thread"
+        data-host="{{ theme.cusdis.host || 'https://cusdis.com' }}"
+        data-app-id="{{ theme.cusdis.app_id }}"
+        data-page-id="{{ page.path }}"
+        data-page-url="{{ page.permalink }}"
+        data-page-title="{{ page.title }}"
+      ></div>
     {%- endif -%}
   </div>
 {%- endif -%}

--- a/layout/_script/_comments/cusdis.swig
+++ b/layout/_script/_comments/cusdis.swig
@@ -1,0 +1,3 @@
+{%- if theme.cusdis.enable -%}
+  <script async src="{{ theme.cusdis.host || 'https://cusdis.com' }}/js/cusdis.es.js"></script>
+{%- endif -%}

--- a/layout/_script/comments.swig
+++ b/layout/_script/comments.swig
@@ -4,4 +4,5 @@
   {%- include "_comments/livere.swig" -%}
   {%- include "_comments/gitalk.swig" -%}
   {%- include "_comments/utterances.swig" -%}
+  {%- include "_comments/cusdis.swig" -%}
 {%- endif -%}


### PR DESCRIPTION
Hi. This PR supports Cusdis (https://cusdis.com), which is an open-source alternative to Disqus.

Preview:

![image](https://user-images.githubusercontent.com/914329/115965179-641a0a80-a55a-11eb-927d-a83c155bc6f8.png)

It can be enable by setting `cusdis` in theme's `_config.yml`:

```yaml
cusdis:
  enable: true
  app_id: xxx
```