### PR TITLE
Upgrade the Leancloud CDN and config.

### DIFF
--- a/_config.yml.example
+++ b/_config.yml.example
@@ -77,6 +77,8 @@ social:
 leancloud:
   app_id:
   app_key:
+  server_url:
+  cdn:
 
 # Baidu Analytics
 baidu_analytics:
@@ -131,4 +133,4 @@ utterances:
 # ===========================================
 # Version
 # ===========================================
-version: 2.11.1
+version: 2.11.2

--- a/layout/_script/counter.swig
+++ b/layout/_script/counter.swig
@@ -1,10 +1,10 @@
-{%- if theme.leancloud.app_id and theme.leancloud.app_key -%}
-  <script src="//cdn1.lncld.net/static/js/3.1.1/av-min.js"></script>
+{%- if theme.leancloud.app_id and theme.leancloud.app_key and theme.leancloud.server_url -%}
+  <script src="{{ theme.leancloud.cdn || '//unpkg.com/leancloud-storage@4.12.2/dist/av-min.js' }}"></script>
   <script id="leancloud">
     AV.init({
       appId: "{{ theme.leancloud.app_id }}",
-      appKey: "{{ theme.leancloud.app_key }}"
+      appKey: "{{ theme.leancloud.app_key }}",
+      serverURL: "{{ theme.leancloud.server_url }}"
     });
   </script>
 {%- endif -%}
-


### PR DESCRIPTION
The original implementation uses the old Leancloud CDN and API with [a deprecated domain which is 404 currently](https://leancloudblog.com/lncld-net-client-hold/). The PR upgraded the CDN address so that the counter could work again.

Additionally, Leancloud has required CN Apps to use the specified public domain or custom domain recently, so I also exposed a required config named server_url to support user defined domain.

Considering the Leancloud now depending on the third-party CDN like unpkg/jsdelivr instead of providing an official one, I added an optional CDN config so that the users would be able to use the CDN as they wish.